### PR TITLE
ADD: interface IHttpClientInterceptor for mocking purpose

### DIFF
--- a/Toolbelt.Blazor.HttpClientInterceptor.Test/IHttpClientInterceptorTest.cs
+++ b/Toolbelt.Blazor.HttpClientInterceptor.Test/IHttpClientInterceptorTest.cs
@@ -1,0 +1,83 @@
+using System;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Toolbelt.Blazor.Extensions.DependencyInjection;
+using Toolbelt.Blazor.Test.Internals;
+using Xunit;
+
+namespace Toolbelt.Blazor.Test
+{
+    public class IHttpClientInterceptorTest
+    {
+        private void GetServiceTest(Action<IServiceCollection> configure = null)
+        {
+            var services = new ServiceCollection();
+            services.AddHttpClientInterceptor();
+
+            configure?.Invoke(services);
+
+            var serviceProvider = services.BuildServiceProvider(validateScopes: true);
+
+            serviceProvider.GetService<IHttpClientInterceptor>().IsNotNull();
+
+            using var scope = serviceProvider.CreateScope();
+            scope.ServiceProvider.GetService<IHttpClientInterceptor>().IsNotNull();
+        }
+
+        [Fact]
+        public void HttpClient_as_a_Singleton_Test()
+        {
+            GetServiceTest(configure: services =>
+            {
+                services.AddSingleton<HttpClient>(sp => new HttpClient());
+            });
+        }
+
+        [Fact]
+        public void HttpClient_as_a_Transient_Test()
+        {
+            GetServiceTest(configure: services =>
+            {
+                services.AddTransient<HttpClient>(sp => new HttpClient());
+            });
+        }
+
+        [Fact]
+        public void HttpClient_as_a_Scoped_Test()
+        {
+            GetServiceTest(configure: services =>
+            {
+                services.AddScoped<HttpClient>(sp => new HttpClient());
+            });
+        }
+
+        [Fact]
+        public void No_HttpClient_Registration_Test()
+        {
+            GetServiceTest(/* doesn't register HttpClient to DI container. */);
+        }
+
+        [Fact]
+        public async Task EventCount_with_SingleTonHttpClient_Test()
+        {
+            var services = new ServiceCollection();
+            services.AddHttpClientInterceptor();
+            services.AddSingleton<HttpClient>(sp => new HttpClient(new NullHttpMessageHandler()).EnableIntercept(sp));
+
+            using var serviceProvider = services.BuildServiceProvider(validateScopes: true);
+            var httpClientInterceptor = serviceProvider.GetService<HttpClientInterceptor>();
+
+            var countOfBeforeSend = 0;
+            var countOfAfterSend = 0;
+            httpClientInterceptor.BeforeSend += (_, __) => countOfBeforeSend++;
+            httpClientInterceptor.AfterSend += (_, __) => countOfAfterSend++;
+
+            var httpClient = serviceProvider.GetService<HttpClient>();
+            await httpClient.GetAsync("http://example.com/foo/bar");
+
+            countOfBeforeSend.Is(1);
+            countOfAfterSend.Is(1);
+        }
+    }
+}

--- a/Toolbelt.Blazor.HttpClientInterceptor/HttpClientInterceptor.cs
+++ b/Toolbelt.Blazor.HttpClientInterceptor/HttpClientInterceptor.cs
@@ -7,7 +7,7 @@ namespace Toolbelt.Blazor
     /// <summary>
     /// Intercept all of the sending HTTP requests on a client side Blazor application.
     /// </summary>
-    public class HttpClientInterceptor
+    public class HttpClientInterceptor : IHttpClientInterceptor
     {
         /// <summary>
         /// Occurs before a HTTP request sending.

--- a/Toolbelt.Blazor.HttpClientInterceptor/HttpClientInterceptorExtension.cs
+++ b/Toolbelt.Blazor.HttpClientInterceptor/HttpClientInterceptorExtension.cs
@@ -41,6 +41,12 @@ namespace Toolbelt.Blazor.Extensions.DependencyInjection
 
                 return new HttpClientInterceptor();
             });
+
+            services.TryAddSingleton(services =>
+            {
+                var interceptor = services.GetService<HttpClientInterceptor>();
+                return (IHttpClientInterceptor)interceptor;
+            });
         }
 
         public static HttpClient EnableIntercept(this HttpClient httpClient, IServiceProvider services)

--- a/Toolbelt.Blazor.HttpClientInterceptor/IHttpClientInterceptor.cs
+++ b/Toolbelt.Blazor.HttpClientInterceptor/IHttpClientInterceptor.cs
@@ -1,0 +1,27 @@
+﻿using System;
+
+namespace Toolbelt.Blazor
+{
+    public interface IHttpClientInterceptor
+    {
+        /// <summary>
+        /// Occurs before a HTTP request sending.
+        /// </summary>
+        event EventHandler<HttpClientInterceptorEventArgs> BeforeSend;
+
+        /// <summary>
+        /// Occurs before a HTTP request sending.
+        /// </summary>
+        event HttpClientInterceptorEventHandler BeforeSendAsync;
+
+        /// <summary>
+        /// Occurs after received a response of a HTTP request. (include it wasn't succeeded.)
+        /// </summary>
+        event EventHandler<HttpClientInterceptorEventArgs> AfterSend;
+
+        /// <summary>
+        /// Occurs after received a response of a HTTP request. (include it wasn't succeeded.)
+        /// </summary>
+        event HttpClientInterceptorEventHandler AfterSendAsync;
+    }
+}


### PR DESCRIPTION
Hello! Thank you for useful project.

I added the interface IHttpClientInterceptor for mocking in unit testing and left the old code for compatibility. 
I also added new tests.

So now users can write:
```
@inject IHttpClientInterceptor
```
when they want unit testing class and:
```
@inject HttpClientInterceptor
```
when they don't want to.